### PR TITLE
Prevent non-upper OTP urls from decoding improperly

### DIFF
--- a/hotp.go
+++ b/hotp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // HOTP represents an RFC-4226 Hash-based One Time Password instance.
@@ -64,7 +65,7 @@ func hotpFromURL(u *url.URL) (*HOTP, string, error) {
 	label := u.Path[1:]
 	v := u.Query()
 
-	secret := v.Get("secret")
+	secret := strings.ToUpper(v.Get("secret"))
 	if secret == "" {
 		return nil, "", ErrInvalidURL
 	}

--- a/totp.go
+++ b/totp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -115,7 +116,7 @@ func totpFromURL(u *url.URL) (*TOTP, string, error) {
 	label := u.Path[1:]
 	v := u.Query()
 
-	secret := v.Get("secret")
+	secret := strings.ToUpper(v.Get("secret"))
 	if secret == "" {
 		return nil, "", ErrInvalidURL
 	}


### PR DESCRIPTION
Non-uppercase secrets that are base32 encoded will fial to decode
unless we upper them.